### PR TITLE
Remove cssify as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,16 +28,6 @@
     "develop": "done-serve --static --develop --port 8080"
   },
   "main": "can-view-target",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
   "keywords": [
     "canjs",
     "canjs-plugin",
@@ -55,7 +45,6 @@
   "devDependencies": {
     "bit-docs": "0.0.7",
     "jshint": "^2.9.1",
-    "cssify": "^1.0.3",
     "steal": "^0.16.0",
     "steal-qunit": "^0.1.1",
     "steal-tools": "^0.16.0",


### PR DESCRIPTION
cssify is not used by this package and including it breaks browserify
usage.