### PR TITLE
Keeps non-default element namespace

### DIFF
--- a/can-view-target.js
+++ b/can-view-target.js
@@ -95,7 +95,12 @@ var cloneNode = clonesWork ?
 		var copy;
 
 		if(node.nodeType === 1) {
-			copy = document.createElement(node.nodeName);
+			if(node.namespaceURI !== 'http://www.w3.org/1999/xhtml' && namespacesWork && document.createElementNS) {
+				copy = document.createElementNS(node.namespaceURI, node.nodeName);
+			}
+			else {
+				copy = document.createElement(node.nodeName);
+			}
 		} else if(node.nodeType === 3){
 			copy = document.createTextNode(node.nodeValue);
 		} else if(node.nodeType === 8) {

--- a/test/test.js
+++ b/test/test.js
@@ -175,3 +175,13 @@ test('cloneNode works in IE11', function() {
 		equal(clone.childNodes.length, 1, 'cloneNode should work after creating MutationObserver');
 	}
 });
+
+test('cloneNode keeps non-default element namespace', function() {
+	var frag = document.createDocumentFragment();
+	var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+	frag.appendChild(svg);
+
+	var clone = target.cloneNode(frag);
+
+	equal(clone.firstChild.namespaceURI, 'http://www.w3.org/2000/svg', 'cloneNode should keep non-default element namespace');
+});


### PR DESCRIPTION
This checks for an element not having the default xhtml namespace in the cloneNode function (when cloneNode is not natively supported by the browser or in IE11 where there is a problem with mutation observers) and clones the element with `createElementNS` instead to keep the elements original namespace.

Will fix SVG issues in IE11

for https://github.com/canjs/can-stache/issues/242