### PR TITLE
handling attributes namespace URI

### DIFF
--- a/can-view-target.js
+++ b/can-view-target.js
@@ -162,7 +162,11 @@ function processNode(node, paths, location, document){
 						getCallback().callbacks.push({
 							callback:  value
 						});
-					} else  {
+					} else if (typeof value === "object") {
+						if (value.value && value.namespaceURI) {
+							el.setAttributeNS(value.namespaceURI,attrName,value.value);
+						}
+					} else {
 						domMutate.setAttribute.call(el, attrName, value);
 					}
 				}

--- a/can-view-target.js
+++ b/can-view-target.js
@@ -162,10 +162,8 @@ function processNode(node, paths, location, document){
 						getCallback().callbacks.push({
 							callback:  value
 						});
-					} else if (typeof value === "object") {
-						if (value.value && value.namespaceURI) {
-							el.setAttributeNS(value.namespaceURI,attrName,value.value);
-						}
+					} else if (value !== null && typeof value === "object" && value.namespaceURI) {
+						el.setAttributeNS(value.namespaceURI,attrName,value.value);
 					} else {
 						domMutate.setAttribute.call(el, attrName, value);
 					}

--- a/test/test.js
+++ b/test/test.js
@@ -185,3 +185,17 @@ test('cloneNode keeps non-default element namespace', function() {
 
 	equal(clone.firstChild.namespaceURI, 'http://www.w3.org/2000/svg', 'cloneNode should keep non-default element namespace');
 });
+
+QUnit.test("SVG namespaceURI", function() {
+	var data = target([{
+		tag: "svg",
+		attrs: {
+			"xmlns" : {
+				value: "http://www.w3.org/2000/svg", 
+				namespaceURI: "http://www.w3.org/2000/xmlns/"
+			}
+		}
+	}]);
+	var frag = data.hydrate();
+	QUnit.equal(frag.firstChild.getAttributeNode("xmlns").namespaceURI, 'http://www.w3.org/2000/xmlns/');
+})


### PR DESCRIPTION
This fix allows to set namespaces values for attributes using ```setAttributeNS``` like ```xmlns``` attribute for ```svg``` which have ```xmlns``` attribute with```http://www.w3.org/2000/xmlns/``` as ```namespaceURI```